### PR TITLE
fix: mobile menu visible by default instead of hidden

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -72,7 +72,7 @@ const iconBtn =
         <ul
           id="menu-items"
           class:list={[
-            "hidden",
+            "max-sm:hidden",
             "max-sm:absolute max-sm:top-full max-sm:inset-x-0 max-sm:z-50 max-sm:grid max-sm:grid-cols-2 max-sm:gap-1 max-sm:px-4 max-sm:py-3 max-sm:bg-background/95 max-sm:backdrop-blur-[16px] max-sm:backdrop-saturate-[1.8] max-sm:border-b max-sm:border-border/50",
             "sm:flex sm:items-center sm:gap-1",
           ]}
@@ -175,7 +175,7 @@ const iconBtn =
       menuBtn.setAttribute("aria-expanded", openMenu ? "false" : "true");
       menuBtn.setAttribute("aria-label", openMenu ? "Open Menu" : "Close Menu");
 
-      menuItems.classList.toggle("hidden");
+      menuItems.classList.toggle("max-sm:hidden");
       menuIcon.classList.toggle("hidden");
       closeIcon.classList.toggle("hidden");
     });


### PR DESCRIPTION
Changed base 'hidden' class to 'max-sm:hidden' to prevent responsive grid
class from overriding visibility on mobile. Updated toggle script to work
with mobile-specific class.

https://claude.ai/code/session_011Yo4yycuRxizrfvbKLG2g8