### PR TITLE
Cache Astro build artifacts between daily deploys

### DIFF
--- a/.github/workflows/daily-deploy.yml
+++ b/.github/workflows/daily-deploy.yml
@@ -11,6 +11,15 @@ jobs:
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
       - run: bun install
+
+      - name: Cache Astro build artifacts
+        uses: actions/cache@v4
+        with:
+          path: node_modules/.astro
+          key: astro-build-${{ hashFiles('src/assets/images/**', 'src/data/blog/**/*.{png,jpg,jpeg,gif,webp,svg,avif}') }}
+          restore-keys: |
+            astro-build-
+
       - run: bun run build
       - run: bun run deploy
         env:


### PR DESCRIPTION
Cache node_modules/.astro between CI runs so Sharp doesn't
reprocess unchanged images on every build. Cache key is based
on a hash of image source files, with a fallback restore-key
to always restore the most recent cache.

https://claude.ai/code/session_01XBx8A9u7JSqPbC1JgvSA7c