### PR TITLE
Add RelatedPosts component to blog post layout

### DIFF
--- a/src/components/RelatedPosts.astro
+++ b/src/components/RelatedPosts.astro
@@ -1,0 +1,95 @@
+---
+import type { CollectionEntry } from "astro:content";
+import IconHash from "@/assets/icons/IconHash.svg";
+import { getPath } from "@/utils/getPath";
+import { slugifyStr } from "@/utils/slugify";
+import Datetime from "./Datetime.astro";
+
+type Props = {
+	currentPost: CollectionEntry<"blog">;
+	posts: CollectionEntry<"blog">[];
+};
+
+const { currentPost, posts } = Astro.props;
+
+const currentTags = currentPost.data.tags;
+
+// Score each post by number of shared tags, then sort descending
+const relatedPosts = posts
+	.filter((p) => p.id !== currentPost.id)
+	.map((p) => {
+		const shared = p.data.tags.filter((t: string) =>
+			currentTags.includes(t),
+		).length;
+		return { post: p, shared };
+	})
+	.filter((p) => p.shared > 0)
+	.sort((a, b) => {
+		if (b.shared !== a.shared) return b.shared - a.shared;
+		// Tie-break: newer posts first
+		return (
+			new Date(b.post.data.pubDatetime).getTime() -
+			new Date(a.post.data.pubDatetime).getTime()
+		);
+	})
+	.slice(0, 3)
+	.map((p) => p.post);
+---
+
+{
+	relatedPosts.length > 0 && (
+		<div data-pagefind-ignore>
+			{/* Editorial divider */}
+			<div class="flex items-center gap-4 my-8">
+				<span
+					class="text-xs font-bold uppercase tracking-[0.2em] text-accent whitespace-nowrap"
+					style="font-variant: small-caps;"
+				>
+					Related
+				</span>
+				<span class="flex-1 h-px bg-border/60" />
+			</div>
+
+			<ul class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+				{relatedPosts.map((p) => {
+					const { title, description, tags, ...rest } = p.data;
+					return (
+						<li class="group relative overflow-hidden rounded-xl border border-border/40 bg-muted/20 transition-all duration-300 hover:bg-muted/40 hover:border-border/70 hover:-translate-y-0.5 hover:shadow-lg hover:shadow-accent/5">
+							<div class="relative z-10 p-5">
+								<a
+									href={getPath(p.id, p.filePath)}
+									class="block no-underline after:absolute after:inset-0 after:content-['']"
+								>
+									<h3 class="font-prose text-lg font-bold leading-snug text-foreground transition-colors duration-200 group-hover:text-accent">
+										{title}
+									</h3>
+								</a>
+								<div class="mt-2">
+									<Datetime {...rest} />
+								</div>
+								<p class="mt-2 font-prose text-sm leading-relaxed text-foreground/70 line-clamp-2">
+									{description}
+								</p>
+								{tags.length > 0 && (
+									<ul class="relative z-10 mt-3 flex flex-wrap gap-1.5">
+										{tags.map((tag: string) => (
+											<li>
+												<a
+													href={`/tags/${slugifyStr(tag)}/`}
+													class="inline-flex items-center gap-0.5 rounded-full border border-accent/30 bg-accent/5 px-2.5 py-0.5 text-xs text-accent transition-all duration-150 no-underline hover:border-accent/60 hover:bg-accent/15"
+												>
+													<IconHash class="size-3 opacity-70" />
+													{tag}
+												</a>
+											</li>
+										))}
+									</ul>
+								)}
+							</div>
+						</li>
+					);
+				})}
+			</ul>
+		</div>
+	)
+}

--- a/src/layouts/PostDetails.astro
+++ b/src/layouts/PostDetails.astro
@@ -13,6 +13,7 @@ import Comments from "@/components/Comments.astro";
 import EditPost from "@/components/EditPost.astro";
 import Footer from "@/components/Footer.astro";
 import Header from "@/components/Header.astro";
+import RelatedPosts from "@/components/RelatedPosts.astro";
 import ShareLinks from "@/components/ShareLinks.astro";
 import { SITE } from "@/config";
 import Layout from "@/layouts/Layout.astro";
@@ -258,6 +259,8 @@ const nextPost =
     <BackToTopButton />
 
     <ShareLinks />
+
+    <RelatedPosts currentPost={post} posts={posts} />
 
     <!-- Editorial divider before comments -->
     <div class="flex items-center gap-4 my-8">


### PR DESCRIPTION
Addresses high bounce rate by giving readers navigation options after
finishing articles. The component scores posts by shared tag count,
tie-breaks by recency, and displays up to 3 related posts as styled
cards between share links and comments.

Closes #30

https://claude.ai/code/session_01XLr9X6qHHaLThf8akwtTch