### PR TITLE
Add security.txt (RFC 9116) + yearly expiry-refresh workflow

### DIFF
--- a/.github/workflows/refresh-security-txt.yml
+++ b/.github/workflows/refresh-security-txt.yml
@@ -1,0 +1,32 @@
+name: Refresh security.txt expiry
+on:
+  schedule:
+    - cron: '0 3 1 1 *' # 03:00 UTC, Jan 1st, yearly
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Bump Expires to ~1 year out
+        run: |
+          NEW_EXPIRES=$(date -u -d '+1 year -1 day' +%Y-%m-%dT00:00:00.000Z)
+          sed -i "s|^Expires:.*|Expires: ${NEW_EXPIRES}|" public/.well-known/security.txt
+          echo "Set Expires: ${NEW_EXPIRES}"
+
+      - name: Commit if changed
+        run: |
+          if git diff --quiet; then
+            echo "No change."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add public/.well-known/security.txt
+          git commit -m "chore: refresh security.txt expiry"
+          git push

--- a/public/.well-known/security.txt
+++ b/public/.well-known/security.txt
@@ -1,0 +1,5 @@
+Contact: mailto:help@wicksipedia.com
+Contact: https://github.com/wicksipedia/wicksipedia.com/security/advisories/new
+Expires: 2027-06-07T00:00:00.000Z
+Preferred-Languages: en
+Canonical: https://wicksipedia.com/.well-known/security.txt


### PR DESCRIPTION
Resolves the Cloudflare Security Insights "Security.txt not configured" finding.

- Adds `/.well-known/security.txt` (RFC 9116) with security contact + GitHub advisory link
- Adds a GitHub Action that bumps the `Expires` date yearly so it never goes stale

🤖 Generated with [Claude Code](https://claude.com/claude-code)